### PR TITLE
fix: cherry pick double fix from upstream

### DIFF
--- a/.evergreen/install-dependencies.sh
+++ b/.evergreen/install-dependencies.sh
@@ -11,8 +11,8 @@ NODE_ARTIFACTS_PATH="${PROJECT_DIRECTORY}/node-artifacts"
 NPM_CACHE_DIR="${NODE_ARTIFACTS_PATH}/npm"
 NPM_TMP_DIR="${NODE_ARTIFACTS_PATH}/tmp"
 
-NVM_WINDOWS_URL="https://github.com/coreybutler/nvm-windows/releases/download/1.1.7/nvm-noinstall.zip"
-NVM_URL="https://raw.githubusercontent.com/nvm-sh/nvm/v0.35.3/install.sh"
+NVM_WINDOWS_URL="https://github.com/coreybutler/nvm-windows/releases/download/1.1.9/nvm-noinstall.zip"
+NVM_URL="https://raw.githubusercontent.com/nvm-sh/nvm/v0.38.0/install.sh"
 
 # this needs to be explicitly exported for the nvm install below
 export NVM_DIR="${NODE_ARTIFACTS_PATH}/nvm"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "bson",
     "parser"
   ],
-  "version": "2.0.6",
+  "version": "2.0.7",
   "author": "Christian Amor Kvalheim <christkv@gmail.com>",
   "contributors": [],
   "dependencies": {

--- a/src/bson.cc
+++ b/src/bson.cc
@@ -332,11 +332,21 @@ void BSONSerializer<T>::SerializeValue(void *typeLocation,
   // Process all the values
   if (value->IsNumber()) {
     double doubleValue = NanTo<double>(value);
-    int intValue = (int)doubleValue;
-    if (intValue == doubleValue) {
+    double flooredValue = std::floor(doubleValue);
+    bool isNegativeZero = std::signbit(doubleValue) == true && std::fpclassify(doubleValue) == FP_ZERO;
+
+    if (isNegativeZero) {
+      // TODO(NODE-4335): -0 should be serialized as double
+      // In order to preserve consistent behavior with js-bson, serialize -0.0 as an int32
       this->CommitType(typeLocation, BSON_TYPE_INT);
-      this->WriteInt32(intValue);
+      this->WriteInt32(0);
+    } else if (flooredValue == doubleValue && flooredValue <= INT32_MAX && flooredValue >= INT32_MIN) {
+      // If there is no fractional component and we are within an [int32.min, int32.max]
+      // write a bson int32
+      this->CommitType(typeLocation, BSON_TYPE_INT);
+      this->WriteInt32(flooredValue);
     } else {
+      // otherwise write the double
       this->CommitType(typeLocation, BSON_TYPE_NUMBER);
       this->WriteDouble(doubleValue);
     }

--- a/test/node/number_test.js
+++ b/test/node/number_test.js
@@ -1,0 +1,149 @@
+'use strict';
+
+const expect = require('chai').expect;
+
+const BSON = require('../..');
+
+const BSON_DOUBLE_TYPE = 0x01;
+const BSON_INT32_TYPE = 0x10;
+
+const INT32_MAX = 2147483647;
+const INT32_MIN = -2147483648;
+
+const nanPayloadBuffer = Buffer.from('120000000000F87F', 'hex');
+const nanPayloadDV = new DataView(
+  nanPayloadBuffer.buffer,
+  nanPayloadBuffer.byteOffset,
+  nanPayloadBuffer.byteLength
+);
+const nanPayloadDouble = nanPayloadDV.getFloat64(0, true);
+
+describe('serializing javascript numbers', () => {
+  it('serialize a number that exceeds int32.max as a double', () => {
+    const document = { a: INT32_MAX + 1 };
+    const bytes = BSON.serialize(document);
+
+    expect(bytes[4]).to.equal(BSON_DOUBLE_TYPE);
+
+    const returnedDocument = BSON.deserialize(bytes);
+    expect(returnedDocument).to.deep.equal(document);
+  });
+
+  it('serialize a number that negatively exceeds int32.min as a double', () => {
+    const document = { a: INT32_MIN - 1 };
+    const bytes = BSON.serialize(document);
+
+    expect(bytes[4]).to.equal(BSON_DOUBLE_TYPE);
+
+    const returnedDocument = BSON.deserialize(bytes);
+    expect(returnedDocument).to.deep.equal(document);
+  });
+
+  it('serialize a number that is exactly int32.max as int32', () => {
+    const document = { a: INT32_MAX };
+    const bytes = BSON.serialize(document);
+
+    expect(bytes[4]).to.equal(BSON_INT32_TYPE);
+
+    const returnedDocument = BSON.deserialize(bytes);
+    expect(returnedDocument).to.deep.equal(document);
+  });
+
+  it('serialize a number that is exactly int32.min as int32', () => {
+    const document = { a: INT32_MIN };
+    const bytes = BSON.serialize(document);
+
+    expect(bytes[4]).to.equal(BSON_INT32_TYPE);
+
+    const returnedDocument = BSON.deserialize(bytes);
+    expect(returnedDocument).to.deep.equal(document);
+  });
+
+  it('serialize a number that has a fractional component as double', () => {
+    const document = { a: 2.3 };
+    const bytes = BSON.serialize(document);
+
+    expect(bytes[4]).to.equal(BSON_DOUBLE_TYPE);
+
+    const returnedDocument = BSON.deserialize(bytes);
+    expect(returnedDocument).to.deep.equal(document);
+  });
+
+  it.skip('preserve -0.0 through round trip -- TODO(NODE-4335)', () => {
+    // TODO(NODE-4335): -0 be serialized as double
+    const document = { a: -0.0 };
+    const bytes = BSON.serialize(document);
+
+    expect(bytes[4]).to.equal(BSON_DOUBLE_TYPE);
+
+    const returnedDocument = BSON.deserialize(bytes);
+    expect(returnedDocument).to.deep.equal(document);
+    expect(Object.is(returnedDocument.a, -0.0)).to.be.true;
+  });
+
+  it('preserve Double(-0.0) through round trip -- TODO(NODE-4335)', () => {
+    // TODO(NODE-4335): -0 be serialized as double
+    const document = { a: new BSON.Double(-0.0) };
+    const bytes = BSON.serialize(document);
+
+    expect(bytes[4]).to.equal(BSON_DOUBLE_TYPE);
+
+    const returnedDocument = BSON.deserialize(bytes, { promoteValues: false });
+    expect(returnedDocument).to.deep.equal(document);
+    expect(Object.is(returnedDocument.a.valueOf(), -0.0)).to.be.true;
+  });
+
+  it('converts -0.0 to an int32 -- TODO(NODE-4335)', () => {
+    // TODO(NODE-4335): -0 be serialized as double
+    // This test is demonstrating the behavior of -0 being serialized as an int32 something we do NOT want to unintentionally change, but may want to change in the future, which the above ticket serves to track.
+    const document = { a: -0.0 };
+    const bytes = BSON.serialize(document);
+
+    expect(bytes[4]).to.equal(BSON_INT32_TYPE);
+
+    const returnedDocument = BSON.deserialize(bytes);
+    expect(returnedDocument).to.have.property('a', 0);
+    expect(Object.is(returnedDocument.a, -0.0)).to.be.false;
+  });
+
+  it('preserve NaN through round trip', () => {
+    const document = { a: NaN };
+    const bytes = BSON.serialize(document);
+
+    expect(bytes[4]).to.equal(BSON_DOUBLE_TYPE);
+
+    const returnedDocument = BSON.deserialize(bytes);
+    expect(returnedDocument).to.deep.equal(document);
+  });
+
+  it('preserve NaN with payload through round trip', () => {
+    const document = { a: nanPayloadDouble };
+    const bytes = BSON.serialize(document);
+
+    expect(bytes[4]).to.equal(BSON_DOUBLE_TYPE);
+    expect(bytes.subarray(7, 15)).to.deep.equal(nanPayloadBuffer);
+
+    const returnedDocument = BSON.deserialize(bytes);
+    expect(returnedDocument).to.deep.equal(document);
+  });
+
+  it('preserve Infinity through round trip', () => {
+    const document = { a: Infinity };
+    const bytes = BSON.serialize(document);
+
+    expect(bytes[4]).to.equal(BSON_DOUBLE_TYPE);
+
+    const returnedDocument = BSON.deserialize(bytes);
+    expect(returnedDocument).to.deep.equal(document);
+  });
+
+  it('preserve -Infinity through round trip', () => {
+    const document = { a: -Infinity };
+    const bytes = BSON.serialize(document);
+
+    expect(bytes[4]).to.equal(BSON_DOUBLE_TYPE);
+
+    const returnedDocument = BSON.deserialize(bytes);
+    expect(returnedDocument).to.deep.equal(document);
+  });
+});


### PR DESCRIPTION
This PR cherry picks a fix for double serialization that fixes a problem with storing of large integers on ARM architecture.